### PR TITLE
Remove deprecation warnings on 0.4

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -24,7 +24,7 @@ Notes
  * This implementation mimics the :class:`IOStream` implementation, and should
    be a drop-in replacement for :class:`IOStream`, with some caveats:
 
-   * :func:`seek_end` and :func:`truncate` are not available
+   * :func:`seekend` and :func:`truncate` are not available
    * :func:`readuntil` is available, but is not very efficient.
      (But :func:`readline` works fine.)
 
@@ -43,7 +43,7 @@ following :class:`IO`/:class:`IOStream` functions are supported:
  * :func:`write()`
  * :func:`peek()`
 
-Due to limitations in ``zlib``, :func:`seek_end` and :func:`truncate` are not available.
+Due to limitations in ``zlib``, :func:`seekend` and :func:`truncate` are not available.
 
 ---------
 Functions

--- a/src/GZip.jl
+++ b/src/GZip.jl
@@ -94,7 +94,7 @@ GZipStream(name::String, gz_file::Ptr{Void}) = GZipStream(name, gz_file, Z_DEFAU
 function gzerror(err::Integer, s::GZipStream)
     e = Int32[err]
     if !s._closed
-        msg_p = ccall((:gzerror, _zlib), Ptr{Uint8}, (Ptr{Void}, Ptr{Int32}),
+        msg_p = ccall((:gzerror, _zlib), Ptr{UInt8}, (Ptr{Void}, Ptr{Int32}),
                       s.gz_file, e)
         msg = (msg_p == C_NULL ? "" : bytestring(msg_p))
     else
@@ -108,7 +108,7 @@ type GZError <: Exception
     err::Int32
     err_str::String
 
-    GZError(e::Integer, str::String) = new(int32(e), str)
+    GZError(e::Integer, str::String) = new(@compat(Int32(e)), str)
     GZError(e::Integer, s::GZipStream) = (a = gzerror(e, s); new(a[1], a[2]))
     GZError(s::GZipStream) = (a = gzerror(s); new(a[1], a[2]))
 end
@@ -171,25 +171,34 @@ gzgetc_raw(s::GZipStream) = ccall((:gzgetc, _zlib), Int32, (Ptr{Void},), s.gz_fi
 gzungetc(c::Integer, s::GZipStream) =
     @test_eof_gzerr(s, ccall((:gzungetc, _zlib), Int32, (Int32, Ptr{Void}), c, s.gz_file), -1)
 
-gzgets(s::GZipStream, a::Array{Uint8}) =
-    @test_eof_gzerr2(s, ccall((:gzgets, _zlib), Ptr{Uint8}, (Ptr{Void}, Ptr{Uint8}, Int32),
-                              s.gz_file, a, int32(length(a))),          C_NULL)
+gzgets(s::GZipStream, a::Array{UInt8}) =
+    @test_eof_gzerr2(s,
+                     ccall((:gzgets, _zlib), Ptr{UInt8}, (Ptr{Void}, Ptr{UInt8}, Int32),
+                           s.gz_file, a, @compat(Int32(length(a)))),
+                     C_NULL)
 
-gzgets(s::GZipStream, p::Ptr{Uint8}, len::Integer) =
-    @test_eof_gzerr2(s, ccall((:gzgets, _zlib), Ptr{Uint8}, (Ptr{Void}, Ptr{Uint8}, Int32),
-                              s.gz_file, p, int32(len)),                C_NULL)
+gzgets(s::GZipStream, p::Ptr{UInt8}, len::Integer) =
+    @test_eof_gzerr2(s,
+                     ccall((:gzgets, _zlib), Ptr{UInt8}, (Ptr{Void}, Ptr{UInt8}, Int32),
+                           s.gz_file, p, @compat(Int32(len))),
+                     C_NULL)
 
 gzputc(s::GZipStream, c::Integer) =
-    @test_gzerror(s, ccall((:gzputc, _zlib), Int32, (Ptr{Void}, Int32),
-                           s.gz_file, int32(c)),                        -1)
+    @test_gzerror(s,
+                  ccall((:gzputc, _zlib), Int32, (Ptr{Void}, Int32),
+                        s.gz_file, @compat(Int32(c))),
+                  -1)
 
 gzwrite(s::GZipStream, p::Ptr, len::Integer) =
-    len == 0 ? int32(0) : @test_gzerror0(s, ccall((:gzwrite, _zlib), Int32, (Ptr{Void}, Ptr{Void}, Uint32),
-                                                   s.gz_file, p, len))
+    len == 0 ? @compat(Int32(0)) :
+               @test_gzerror0(s, ccall((:gzwrite, _zlib), Int32, (Ptr{Void}, Ptr{Void}, UInt32),
+                                       s.gz_file, p, len))
 
 gzread(s::GZipStream, p::Ptr, len::Integer) =
-    @test_gzerror(s, ccall((:gzread, _zlib), Int32, (Ptr{Void}, Ptr{Void}, Uint32),
-                           s.gz_file, p, len),                          -1)
+    @test_gzerror(s,
+                  ccall((:gzread, _zlib), Int32, (Ptr{Void}, Ptr{Void}, UInt32),
+                        s.gz_file, p, len),
+                  -1)
 
 let _zlib_h = dlopen(_zlib)
     global gzbuffer, _gzopen, _gzseek, _gztell
@@ -197,9 +206,9 @@ let _zlib_h = dlopen(_zlib)
     # Doesn't exist in zlib 1.2.3 or earlier
     if dlsym_e(_zlib_h, :gzbuffer) != C_NULL
         gzbuffer(gz_file::Ptr, gz_buf_size::Integer) =
-           ccall((:gzbuffer, _zlib), Int32, (Ptr{Void}, Uint32), gz_file, gz_buf_size)
+           ccall((:gzbuffer, _zlib), Int32, (Ptr{Void}, UInt32), gz_file, gz_buf_size)
     else
-        gzbuffer(gz_file::Ptr, gz_buf_size::Integer) = int32(-1)
+        gzbuffer(gz_file::Ptr, gz_buf_size::Integer) = @compat Int32(-1)
     end
 
     #####
@@ -232,7 +241,7 @@ function gzopen(fname::String, gzmode::String, gz_buf_size::Integer)
         gzmode *= "b"
     end
 
-    gz_file = ccall((_gzopen, _zlib), Ptr{Void}, (Ptr{Uint8}, Ptr{Uint8}), fname, gzmode)
+    gz_file = ccall((_gzopen, _zlib), Ptr{Void}, (Ptr{UInt8}, Ptr{UInt8}), fname, gzmode)
     if gz_file == C_NULL
         throw(GZError(-1, "gzopen failed"))
     end
@@ -264,7 +273,7 @@ function gzdopen(name::String, fd::Integer, gzmode::String, gz_buf_size::Integer
     # not to close the original fd
     dup_fd = ccall(:dup, Int32, (Int32,), fd)
 
-    gz_file = ccall((:gzdopen, _zlib), Ptr{Void}, (Int32, Ptr{Uint8}), dup_fd, gzmode)
+    gz_file = ccall((:gzdopen, _zlib), Ptr{Void}, (Int32, Ptr{UInt8}), dup_fd, gzmode)
     if gz_file == C_NULL
         throw(GZError(-1, "gzdopen failed"))
     end
@@ -306,7 +315,7 @@ function close(s::GZipStream)
 end
 
 flush(s::GZipStream, fl::Integer) =
-    @test_z_ok ccall((:gzflush, _zlib), Int32, (Ptr{Void}, Int32), s.gz_file, int32(fl))
+    @test_z_ok ccall((:gzflush, _zlib), Int32, (Ptr{Void}, Int32), s.gz_file, @compat(Int32(fl)))
 flush(s::GZipStream) = flush(s, Z_SYNC_FLUSH)
 
 truncate(s::GZipStream, n::Integer) = error("truncate is not supported for GZipStreams")
@@ -328,7 +337,7 @@ skip(s::GZipStream, n::Integer) =
 position(s::GZipStream) =
     ccall((_gztell, _zlib), ZFileOffset, (Ptr{Void},), s.gz_file)
 
-eof(s::GZipStream) = bool(ccall((:gzeof, _zlib), Int32, (Ptr{Void},), s.gz_file))
+eof(s::GZipStream) = @compat Bool(ccall((:gzeof, _zlib), Int32, (Ptr{Void},), s.gz_file))
 
 function peek(s::GZipStream)
     c = gzgetc_raw(s)
@@ -344,7 +353,7 @@ function read{T}(s::GZipStream, a::Array{T})
         nb = length(a)*sizeof(T)
         # Note: this will overflow and succeed without warning if nb > 4GB
         ret = ccall((:gzread, _zlib), Int32,
-                    (Ptr{Void}, Ptr{Void}, Uint32), s.gz_file, a, nb)
+                    (Ptr{Void}, Ptr{Void}, UInt32), s.gz_file, a, nb)
         if ret == -1
             throw(GZError(s))
         end
@@ -358,20 +367,20 @@ function read{T}(s::GZipStream, a::Array{T})
     end
 end
 
-function read(s::GZipStream, ::Type{Uint8})
+function read(s::GZipStream, ::Type{UInt8})
     ret = gzgetc(s)
     if ret == -1
         throw(GZError(s))
     end
     peek(s) # force eof to be set
-    uint8(ret)
+    @compat UInt8(ret)
 end
 
 
 # For this function, it's really unfortunate that zlib is
 # not integrated with ios
 function readall(s::GZipStream, bufsize::Int)
-    buf = Array(Uint8, bufsize)
+    buf = Array(UInt8, bufsize)
     len = 0
     while true
         ret = gzread(s, pointer(buf)+len, bufsize)
@@ -402,7 +411,7 @@ end
 readall(s::GZipStream) = readall(s, Z_BIG_BUFSIZE)
 
 function readline(s::GZipStream)
-    buf = Array(Uint8, GZ_LINE_BUFSIZE)
+    buf = Array(UInt8, GZ_LINE_BUFSIZE)
     pos = 1
 
     if gzgets(s, buf) == C_NULL      # Throws an exception on error
@@ -434,7 +443,7 @@ function readline(s::GZipStream)
     end
 end
 
-write(s::GZipStream, b::Uint8) = gzputc(s, b)
+write(s::GZipStream, b::UInt8) = gzputc(s, b)
 
 function write{T}(s::GZipStream, a::Array{T})
     if isbits(T)

--- a/src/zlib_h.jl
+++ b/src/zlib_h.jl
@@ -5,32 +5,32 @@
 
 # Constants
 
-zlib_version = bytestring(ccall((:zlibVersion, _zlib), Ptr{Uint8}, ()))
-ZLIB_VERSION = tuple([int(c) for c in split(zlib_version, '.')]...)
+zlib_version = bytestring(ccall((:zlibVersion, _zlib), Ptr{UInt8}, ()))
+ZLIB_VERSION = tuple([parseint(c) for c in split(zlib_version, '.')]...)
 
 # Flush values
-const Z_NO_FLUSH       = int32(0)
-const Z_PARTIAL_FLUSH  = int32(1)
-const Z_SYNC_FLUSH     = int32(2)
-const Z_FULL_FLUSH     = int32(3)
-const Z_FINISH         = int32(4)
-const Z_BLOCK          = int32(5)
-const Z_TREES          = int32(6)
+const Z_NO_FLUSH       = @compat Int32(0)
+const Z_PARTIAL_FLUSH  = @compat Int32(1)
+const Z_SYNC_FLUSH     = @compat Int32(2)
+const Z_FULL_FLUSH     = @compat Int32(3)
+const Z_FINISH         = @compat Int32(4)
+const Z_BLOCK          = @compat Int32(5)
+const Z_TREES          = @compat Int32(6)
 
 # Return codes
-const Z_OK             = int32(0)
-const Z_STREAM_END     = int32(1)
-const Z_NEED_DICT      = int32(2)
-const Z_ERRNO          = int32(-1)
-const Z_STREAM_ERROR   = int32(-2)
-const Z_DATA_ERROR     = int32(-3)
-const Z_MEM_ERROR      = int32(-4)
-const Z_BUF_ERROR      = int32(-5)
-const Z_VERSION_ERROR  = int32(-6)
+const Z_OK             = @compat Int32(0)
+const Z_STREAM_END     = @compat Int32(1)
+const Z_NEED_DICT      = @compat Int32(2)
+const Z_ERRNO          = @compat Int32(-1)
+const Z_STREAM_ERROR   = @compat Int32(-2)
+const Z_DATA_ERROR     = @compat Int32(-3)
+const Z_MEM_ERROR      = @compat Int32(-4)
+const Z_BUF_ERROR      = @compat Int32(-5)
+const Z_VERSION_ERROR  = @compat Int32(-6)
 
 
 # Zlib errors as Exceptions
-zerror(e::Integer) = bytestring(ccall((:zError, _zlib), Ptr{Uint8}, (Int32,), e))
+zerror(e::Integer) = bytestring(ccall((:zError, _zlib), Ptr{UInt8}, (Int32,), e))
 type ZError <: Exception
     err::Int32
     err_str::String
@@ -39,26 +39,26 @@ type ZError <: Exception
 end
 
 # Compression Levels
-const Z_NO_COMPRESSION      = int32(0)
-const Z_BEST_SPEED          = int32(1)
-const Z_BEST_COMPRESSION    = int32(9)
-const Z_DEFAULT_COMPRESSION = int32(-1)
+const Z_NO_COMPRESSION      = @compat Int32(0)
+const Z_BEST_SPEED          = @compat Int32(1)
+const Z_BEST_COMPRESSION    = @compat Int32(9)
+const Z_DEFAULT_COMPRESSION = @compat Int32(-1)
 
 # Compression Strategy
-const Z_FILTERED             = int32(1)
-const Z_HUFFMAN_ONLY         = int32(2)
-const Z_RLE                  = int32(3)
-const Z_FIXED                = int32(4)
-const Z_DEFAULT_STRATEGY     = int32(0)
+const Z_FILTERED             = @compat Int32(1)
+const Z_HUFFMAN_ONLY         = @compat Int32(2)
+const Z_RLE                  = @compat Int32(3)
+const Z_FIXED                = @compat Int32(4)
+const Z_DEFAULT_STRATEGY     = @compat Int32(0)
 
 # data_type field
-const Z_BINARY    = int32(0)
-const Z_TEXT      = int32(1)
+const Z_BINARY    = @compat Int32(0)
+const Z_TEXT      = @compat Int32(1)
 const Z_ASCII     = Z_TEXT
-const Z_UNKNOWN   = int32(2)
+const Z_UNKNOWN   = @compat Int32(2)
 
 # deflate compression method
-const Z_DEFLATED    = int32(8)
+const Z_DEFLATED    = @compat Int32(8)
 
 # misc
 const Z_NULL   = C_NULL
@@ -68,22 +68,23 @@ const Z_DEFAULT_BUFSIZE = 8192
 const Z_BIG_BUFSIZE = 131072
 
 # Constants for use with gzseek
-const SEEK_SET = int32(0)
-const SEEK_CUR = int32(1)
+const SEEK_SET = @compat Int32(0)
+const SEEK_CUR = @compat Int32(1)
 
 # Create ZFileOffset alias
-# This is usually the same as FileOffset, 
+# This is usually the same as FileOffset,
 # unless we're on a 32-bit system and
 # 64-bit functions are not available
 
 # Get compile-time option flags
-zlib_compile_flags = ccall((:zlibCompileFlags, _zlib), Uint, ())
+zlib_compile_flags = ccall((:zlibCompileFlags, _zlib), UInt, ())
 
 let _zlib_h = dlopen(_zlib)
     global ZFileOffset
 
-    z_off_t_sz   = 2 << ((zlib_compile_flags >> 6) & uint(3))
-    if z_off_t_sz == sizeof(FileOffset) || (sizeof(FileOffset) == 8 && dlsym_e(_zlib_h, :gzopen64) != C_NULL)
+    z_off_t_sz   = 2 << ((zlib_compile_flags >> 6) & @compat(UInt(3)))
+    if z_off_t_sz == sizeof(FileOffset) ||
+       (sizeof(FileOffset) == 8 && dlsym_e(_zlib_h, :gzopen64) != C_NULL)
         typealias ZFileOffset FileOffset
     elseif z_off_t_sz == 4      # 64-bit functions not available
         typealias ZFileOffset Int32

--- a/src/zlib_h.jl
+++ b/src/zlib_h.jl
@@ -6,7 +6,7 @@
 # Constants
 
 zlib_version = bytestring(ccall((:zlibVersion, _zlib), Ptr{UInt8}, ()))
-ZLIB_VERSION = tuple([parseint(c) for c in split(zlib_version, '.')]...)
+ZLIB_VERSION = tuple([parse(Int, c) for c in split(zlib_version, '.')]...)
 
 # Flush values
 const Z_NO_FLUSH       = @compat Int32(0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -66,10 +66,15 @@ close(gzfile)
 # Screw up the file
 raw_file = open(test_compressed, "r+")
 seek(raw_file, 3) # leave the gzip magic 2-byte header
-write(raw_file, zeros(Uint8, 10))
+write(raw_file, zeros(UInt8, 10))
 close(raw_file)
 
-@test_throws ArgumentError gzopen(readall, test_compressed)
+try
+    gzopen(readall, test_compressed)
+    throw(Error("Expecting an ArgumentError or similar"))
+catch e
+    @test isa(e, ArgumentError) || contains(e.msg, "too many arguments")
+end
 
 
 ##########################
@@ -92,7 +97,7 @@ pos = position(gzfile)
 
 gzopen(test_empty, "w") do io
     a = "".data
-    @test gzwrite(io, pointer(a), length(a)*sizeof(eltype(a))) == int32(0)
+    @test gzwrite(io, pointer(a), length(a)*sizeof(eltype(a))) == @compat Int32(0)
 end
 
 ##########################
@@ -153,7 +158,7 @@ end
 
 let BUFSIZE = 65536
     for level = 0:3:6
-        for T in [Int8,Uint8,Int16,Uint16,Int32,Uint32,Int64,Uint64,Int128,Uint128,
+        for T in [Int8,UInt8,Int16,UInt16,Int32,UInt32,Int64,UInt64,Int128,UInt128,
                   Float32,Float64,Complex64,Complex128]
 
             minval = 34567


### PR DESCRIPTION
As a bonus, takes care of the Task switching bug that's keeping DataFrames tests from running on 0.4