### PR TITLE
Add GZipBufferedStream for buffered reading

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -227,8 +227,25 @@ try
             end
         end
     end
+
+
+    # Simple test for buffered GZip functions
+    GZip.open(test_compressed, "wb") do io
+        for i=1:10_000_000
+            write(io, rand(UInt8))
+        end
+    end
+
+    GZip.open(test_compressed, buffered=true) do io
+        while true
+            read(io, UInt8)
+            eof(io) && break
+        end
+    end
 finally
     rm(tmp, recursive=true)
 end
 
 #end  # for epoch
+run(`rm -Rf $tmp`)
+


### PR DESCRIPTION
Also introduces new `gzbopen()` function that generates `GZipBufferedStream`s.

`read`ing a character stream from a `GZipBufferedStream` is ~6x faster than from an ordinary `GZipStream`. The speedup comes from managing an internal `IOBuffer` and populating it with `gzread()`, rather than making a call to the unbuffered `gzgetc()` each time a character is sought.

Here are some benchmark numbers for how the performance varies with buffer size. 0 = ordinary `GZipStream`, sys = system time for `gunzip`. 2^12 = 8192 is the default buffer size and 2^17 = 131072 is the "big" buffer size used by GZip.

(`gunzip` is still 2.8x faster though...)

| log2(buf_size) | time(s) |
| --- | --- |
| 0	| 9.434 |
| 12 (default)	| 1.484 |
| 13	| 1.505 |
| 14	| 1.504 |
| 15	| 1.479 |
| 16	| 1.504 |
| 17	| 1.497 |
| 18	| 1.481 |
| 19	| 1.496 |
| 20	| 1.497 |
| 21	| 1.487 |
| 22	| 1.467 |
| 23	| 1.470 |
| 24	| 1.442 |
| 25	| 1.417 |
| 26	| 1.376 |
| 27	| 1.310 |
| 28 (entire file fits)	| 1.264 |
| sys   | 0.519 |

Benchmark code:

```jl
function benchmark(nreps=10)
  filename = "ALL.chrY.phase3_integrated_v1a.20130502.genotypes.vcf.gz"
  isfile(filename) || download("ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/release/20130502/ALL.chrY.phase3_integrated_v1a.20130502.genotypes.vcf.gz")

  timings=Dict{Int,Vector}()
  for i=1:nreps
    gzbopen(filename) do io
        n = 0
        t = @elapsed while true
            read(io, UInt8)
            n += 1
            eof(io) && break
        end
        timings[0] = push!(get(timings, 0, Float64[]), t)
    end

    for sexp in 28:-1:12
        println("Buffer size: ", 2^sexp)
        n = 0
        io = gzbopen(filename, "rb", 2^sexp)
        t = @elapsed while true
            read(io, UInt8)
            n += 1
            eof(io) && break
        end
        timings[sexp] = push!(get(timings, sexp, Float64[]), t)
        close(io)
    end

    for k in sort!(collect(keys(timings)))
        println(k, '\t', minimum(timings[k]))
    end
  end
end
```