### PR TITLE
Do not mess with the GC

### DIFF
--- a/src/GZip.jl
+++ b/src/GZip.jl
@@ -299,17 +299,10 @@ gzdopen(s::IOStream, args...) = gzdopen(fd(s), args...)
 fd(s::GZipStream) = error("fd is not supported for GZipStreams")
 
 function close(s::GZipStream)
-
-    # The garbage collector needs to be temporarily disabled because of a possible
-    # race condition if it runs between testing and setting s._closed
-
-    gc_enable(false)
     if s._closed
-        gc_enable(true)
         return Z_STREAM_ERROR
     end
     s._closed = true
-    gc_enable(true)
 
     s.name *= " (closed)"
 


### PR DESCRIPTION
There shouldn't be a race condition here.

* If the function is called manually, the variable is referenced from the stack.
* If the function is called called as finalizer, the GC will make sure it is not called twice.
