### PR TITLE
clear deprecation warnings for 0.4.0-RC1

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,7 @@ test_empty = joinpath(tmp, "empty.jl.gz")
 
 test_gunzip = true
 try
-    run(@compat pipe(`which $gunzip`, DevNull))
+    run(@compat pipeline(`which $gunzip`, DevNull))
 catch
     test_gunzip = false
 end


### PR DESCRIPTION
This was a four character insert. Someone did the 0.4.x compatibility. They even inserted the right `@compat`. But, the old `pipe` was never replaced with `pipeline`, which `Compat.jl` defines appropriately. 