### PR TITLE
Use 0.3 and 0.4 for travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ os:
     - osx
     - linux
 julia:
-    - release
+    - 0.3
+    - 0.4
     - nightly
 notifications:
     email: false


### PR DESCRIPTION
Mainly to check if the OSX precompile regression is happing on OSX as well.