### PR TITLE
Set the EOF flag when opening empty files.

### DIFF
--- a/src/GZip.jl
+++ b/src/GZip.jl
@@ -255,7 +255,9 @@ function gzopen(fname::AbstractString, gzmode::AbstractString, gz_buf_size::Inte
             gz_buf_size = Z_DEFAULT_BUFSIZE
         end
     end
-    return GZipStream(fname, gz_file, gz_buf_size)
+    s = GZipStream(fname, gz_file, gz_buf_size)
+    peek(s) # Set EOF-bit for empty files
+    return s
 end
 gzopen(fname::AbstractString, gzmode::AbstractString) = gzopen(fname, gzmode, Z_DEFAULT_BUFSIZE)
 gzopen(fname::AbstractString) = gzopen(fname, "rb", Z_DEFAULT_BUFSIZE)
@@ -287,7 +289,9 @@ function gzdopen(name::AbstractString, fd::Integer, gzmode::AbstractString, gz_b
             gz_buf_size = Z_DEFAULT_BUFSIZE
         end
     end
-    return GZipStream(name, gz_file, gz_buf_size)
+    s = GZipStream(name, gz_file, gz_buf_size)
+    peek(s) # Set EOF-bit for empty files
+    return s
 end
 gzdopen(fd::Integer, gzmode::AbstractString, gz_buf_size::Integer) = gzdopen(string("<fd ",fd,">"), fd, gzmode, gz_buf_size)
 gzdopen(fd::Integer, gz_buf_size::Integer) = gzdopen(fd, "rb", gz_buf_size)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -156,6 +156,14 @@ try
         end
     end
 
+    # Test to create and read an empty file
+    gzfile = gzopen(test_compressed, "wb")
+    @test write(gzfile, "") == 0
+    @test close(gzfile) == Z_OK
+    gzfile = gzopen(test_compressed, "r")
+    @test eof(gzfile) == true
+    @test close(gzfile) == Z_OK
+
     ##########################
     # test_group("gzip array/matrix tests (write/read)")
     ##########################


### PR DESCRIPTION
This PR includes a test that fails prior to this PR. Below is another use case that fails before this PR:

    ;touch foo
    open("foo") do f
        map(println,eachline(f))
    end
    # works fine

    ;gzip foo # creates foo.gz
    GZip.open("foo.gz") do f
        map(println,eachline(f))
    end
    # exception